### PR TITLE
tooling: Replace gometalinter by golangci-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.DS_Store
+
+.bin

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+GOLANGCI_LINT_VERSION := 1.12.3
 
 define HELP_MSG
 Execute one of the following targets:
@@ -13,18 +14,16 @@ help: ## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/:.*##/:##/' | column -t -s '##'
 
 .PHONY: go-tools-install
-go-tools-install: .gti-metalinter ## Install Go tools
+go-tools-install: .gti-golangci-lint ## Install Go tools
 
 .PHONY: lint
 lint: ## Lint the code
-	@gometalinter --vendor --enable-all --line-length=120 --warn-unmatched-nolint --exclude=vendor --exclude=mock_ --deadline=5m ./...
+	@.bin/golangci-lint run --enable-all
 
 .PHONY: .go-tools-install-ci
-.go-tools-install-ci: .gti-metalinter
+.go-tools-install-ci: .gti-golangci-lint
 
-.PHONY: .gti-metalinter
-.gti-metalinter:
-	@go get -u github.com/alecthomas/gometalinter
-# gometalinter --install is deprecated but for now it's the best solution:
-# https://github.com/alecthomas/gometalinter/issues/418
-	@gometalinter --install --update --force --debug
+.PHONY: .gti-golangci-lint
+.gti-golangci-lint:
+	@mkdir -p .bin
+	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b .bin v$(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
Replace the linting tool gometalinter by the golangci-lint because it
should run faster and because allow to use a specific version easily.