### PR TITLE
Changed: Go documentation format for be aligned with Go doc

### DIFF
--- a/payment/errors.go
+++ b/payment/errors.go
@@ -74,7 +74,8 @@ func (c code) Message() string {
 	return ""
 }
 
-// ErrMDArg creates a new  MD (metadata) from an function argument.
+// ErrMDArg creates a new metadata from an function argument which is related
+// with the error to create.
 func ErrMDArg(name string, val interface{}) errors.MD {
 	return errors.MD{
 		K: fmt.Sprintf("arg:%s", name),

--- a/payment/filter.go
+++ b/payment/filter.go
@@ -49,10 +49,12 @@ type FilterLeaf interface {
 }
 
 // Filter is an abstraction of a specified filter over a set of different values.
+//
 // It represents a binary tree where when it's a leaf node, it contains the
 // comparison operator and value to apply, meanwhile when it isn't a left, it
 // contains the 2 children nodes (which are Filter) and the logical operator
 // applied between the both of them.
+//
 // You can see it as any boolean logical operation used in conditionals in the
 // majority of programming languages.
 type Filter struct {
@@ -82,6 +84,7 @@ func (f Filter) Leaf() FilterLeaf {
 
 // Nodes returns the operator applied over the 2 children nodes and those nodes
 // left and right.
+//
 // FilterLogical is an invalid value and the 2 filter will be of node type
 // NodeTypeEmpty, when f is not an NodeTypeNonLeaf.
 func (f Filter) Nodes() (FilterLogical, Filter, Filter) {
@@ -123,9 +126,11 @@ type FilterLeafID struct {
 // specified cmp and val.
 //
 // The following error codes can be returned (declared in errs sub package):
+//
 // * InvalidArgFilterCmpNotExists
-// * InvalidArgFilterCmpNotSupported
-//		when cmp isn't FilterCmpEqual nor FilterCmpNotEqual
+//
+// * InvalidArgFilterCmpNotSupported - when cmp isn't FilterCmpEqual nor
+// FilterCmpNotEqual
 func NewFilterByID(cmp FilterCmp, val uuid.UUID) (Filter, error) {
 	if err := validatepCmp(cmp); err != nil {
 		return Filter{}, err
@@ -162,11 +167,13 @@ type FilterLeafType struct {
 // val.
 //
 // The following error codes can be returned (declared in errs sub package):
+//
 // * InvalidArgFilterCmpNotExists
-// * InvalidArgFilterCmpNotSupported
-//			when cmp isn't FilterCmpEqual nor FilterCmpNotEqual
-// * InvalidArgFilterValue
-//			currently only "Payment" is valid value type
+//
+// * InvalidArgFilterCmpNotSupported - when cmp isn't FilterCmpEqual nor
+// FilterCmpNotEqual
+//
+// * InvalidArgFilterValue - currently only "Payment" is valid value type
 func NewFilterByType(cmp FilterCmp, val string) (Filter, error) {
 	if err := validatepCmp(cmp); err != nil {
 		return Filter{}, err
@@ -199,7 +206,9 @@ type FilterLeafAmount struct {
 // specified cmp and val.
 //
 // The following error codes can be returned (declared in errs sub package):
+//
 // * InvalidArgFilterCmpNotExists
+//
 // * InvalidArgFilterCmpNotSupported - when cmd is FilterCmpMatch
 func NewFilterByAmount(cmp FilterCmp, val float64) (Filter, error) {
 	var f, err = newFilterLeafFloat64(cmp, val)
@@ -214,6 +223,7 @@ func NewFilterByAmount(cmp FilterCmp, val float64) (Filter, error) {
 // It returns an error if f.IsSet returns false.
 //
 // The following error codes may be returned:
+//
 // * InvalidArgFilterLeafNoValSet
 func newFilterLeaf(l FilterLeaf) (Filter, error) {
 	if !l.IsSet() {

--- a/payment/service.go
+++ b/payment/service.go
@@ -13,6 +13,7 @@ import (
 //
 // All the methods can return, a part of their specific ones which are
 // documented on them, the following error codes:
+//
 // * ErrUnexpectedStoreError
 type Service interface {
 	// Create creates a new payment returning its ID.
@@ -31,6 +32,7 @@ type Service interface {
 	// only contains the fields indicated by s.
 	//
 	// The following error codes can be returned:
+	//
 	// * ErrNotFound
 	Get(ctx context.Context, id uuid.UUID, s Selection) (Pymt, error)
 
@@ -38,9 +40,10 @@ type Service interface {
 	// with version. The payment version is incremented if the update succeeds.
 	//
 	// The following error codes can be returned:
-	// * ErrInvalidArgVersionMismatch
-	//		When the version doesn't match with the current payment version for
-	//		avoiding to override the payment concurrently.
+	//
+	// * ErrInvalidArgVersionMismatch - When the version doesn't match with the
+	// current payment version for avoiding to override the payment concurrently.
+	//
 	// * ErrNotFound
 	Update(ctx context.Context, id uuid.UUID, version uint32, p PymtUpsert) error
 }

--- a/payment/sort.go
+++ b/payment/sort.go
@@ -11,6 +11,7 @@ const (
 )
 
 // Sort specifies the allowed fields for sorting a list of payments.
+//
 // The payment's fields which aren't present aren't allowed to be used for
 // sorting.
 type Sort struct {


### PR DESCRIPTION
Add some extra lines in the documentation comments for fulfilling with
the go doc command and get the expected output format.