### PR TITLE
Simplify implementation reducing flexibility

### DIFF
--- a/payment/payment.go
+++ b/payment/payment.go
@@ -1,8 +1,6 @@
 package payment
 
 import (
-	"math/big"
-
 	"github.com/gofrs/uuid"
 )
 
@@ -18,29 +16,29 @@ type PymtUpsert struct {
 	Type           string `json:"type"`
 	OrganisationID string `json:"organisation_id"`
 	Attributes     struct {
-		Amount               *big.Float `json:"amount"`
-		Currency             string     `json:"currency"`
-		Reference            string     `json:"reference"`
-		EndToEndReference    string     `json:"end_to_end_reference"`
-		NumericReference     string     `json:"numeric_reference"`
-		PaymentID            string     `json:"payment_id"`
-		PaymentPurpose       string     `json:"payment_purpose"`
-		PaymentScheme        string     `json:"payment_scheme"`
-		PaymentType          string     `json:"payment_type"`
-		ProcessingDate       string     `json:"processing_date"`
-		SchemePaymentSubType string     `json:"scheme_payment_sub_type"`
-		SchemePaymentType    string     `json:"scheme_payment_type"`
-		BeneficiaryParty     Party      `json:"beneficiary_party"`
-		DebtorParty          Party      `json:"debtor_party"`
-		SponsorParty         Party      `json:"sponsor_party"`
+		Amount               float64 `json:"amount"`
+		Currency             string  `json:"currency"`
+		Reference            string  `json:"reference"`
+		EndToEndReference    string  `json:"end_to_end_reference"`
+		NumericReference     string  `json:"numeric_reference"`
+		PaymentID            string  `json:"payment_id"`
+		PaymentPurpose       string  `json:"payment_purpose"`
+		PaymentScheme        string  `json:"payment_scheme"`
+		PaymentType          string  `json:"payment_type"`
+		ProcessingDate       string  `json:"processing_date"`
+		SchemePaymentSubType string  `json:"scheme_payment_sub_type"`
+		SchemePaymentType    string  `json:"scheme_payment_type"`
+		BeneficiaryParty     Party   `json:"beneficiary_party"`
+		DebtorParty          Party   `json:"debtor_party"`
+		SponsorParty         Party   `json:"sponsor_party"`
 		ChargesInformation   struct {
 			BearerCode    string `json:"bearer_code"`
 			SenderCharges []struct {
-				Amount   *big.Float `json:"amount"`
-				Currency string     `json:"currency"`
+				Amount   float64 `json:"amount"`
+				Currency string  `json:"currency"`
 			} `json:"sender_charges"`
-			ReceiverChargesAmount   *big.Float `json:"receiver_charges_amount"`
-			ReceiverChargesCurrency string     `json:"receiver_charges_currency"`
+			ReceiverChargesAmount   float64 `json:"receiver_charges_amount"`
+			ReceiverChargesCurrency string  `json:"receiver_charges_currency"`
 		} `json:"charges_information"`
 		Fx struct {
 			ContractReference string `json:"contract_reference"`

--- a/payment/selection.go
+++ b/payment/selection.go
@@ -8,26 +8,5 @@ type Selection struct {
 	Type           bool
 	Version        bool
 	OrganisationID bool
-	Attributes     SelectionAttributes
-}
-
-// SelectionAttributes is the type of the Attributes field of the Selection type.
-type SelectionAttributes struct {
-	Amount               bool
-	Currency             bool
-	Reference            bool
-	EndToEndReference    bool
-	NumericReference     bool
-	PaymentID            bool
-	PaymentPurpose       bool
-	PaymentScheme        bool
-	PaymentType          bool
-	ProcessingDate       bool
-	SchemePaymentSubType bool
-	SchemePaymentType    bool
-	BeneficiaryParty     bool
-	DebtorParty          bool
-	SponsorParty         bool
-	ChargesInformation   bool
-	Fx                   bool
+	Attributes     bool
 }

--- a/payment/sort.go
+++ b/payment/sort.go
@@ -24,19 +24,5 @@ type Sort struct {
 
 // SortAttributes is the type of the Attributes field of the Sort type.
 type SortAttributes struct {
-	Amount             SortDir
-	Currency           SortDir
-	Reference          SortDir
-	EndToEndReference  SortDir
-	NumericReference   SortDir
-	PaymentID          SortDir
-	ProcessingDate     SortDir
-	ChargesInformation SortChargesInformation
-}
-
-// SortChargesInformation is the type of the ChargesInformation field of the
-// SortAttributes type.
-type SortChargesInformation struct {
-	SenderChargesAmount   SortDir
-	ReceiverChargesAmount SortDir
+	Amount SortDir
 }


### PR DESCRIPTION
Simplify the implementation reducing features regarding the number of
fields which can be selected or not and the fields which the collections
of payment can be sorted.

The amounts fields of the payment has also be changed to be basic float
types for easing the conversion and because big numbers aren't needed
due to no need to make numeric operations with those.

This is mostly done because this is an example and for the sake to finish the implementation and being able to start to do experimentation in other different areas.