### PR TITLE
CI: Update config to run on Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 
 matrix:
   include:
-    - go: "1.11.x"
+    - go: "1.12.x"
       env: GO111MODULE=on LINT=true COVERAGE=true
     - go: tip
       env: GO111MODULE=on

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_LINT_VERSION := 1.12.3
+GOLANGCI_LINT_VERSION := 1.15.0
 GOLANGCI_LINT_BIN := $(realpath .bin/golangci-lint)
 
 define HELP_MSG


### PR DESCRIPTION
Because Go 1.12 has been released, this project should always run in the
last published version in Go until the project be implemented.