### PR TITLE
Fix CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-go_import_path: go.fraixed.es/errors
 language: go
 
 matrix:


### PR DESCRIPTION
The Travis CI configuration had an invalid configuration parameter, so
it caused to fail when executing it.